### PR TITLE
Swift 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ script and the project import are directly derieved from his work. The video
 he made in the provided link is worth watching.
 
 This covers Unity 5+. At the time of this writing this has been
-successfully used with Unity `5.2.2f1` and `Swift 2.1` under `Xcode 7.1` & `Swift 3.0` under `Xcode 8.0`.
+successfully used with Unity `5.2.2f1` and `Swift 3.0` under `Xcode 8.0`.
 
 This works with storyboards.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ script and the project import are directly derieved from his work. The video
 he made in the provided link is worth watching.
 
 This covers Unity 5+. At the time of this writing this has been
-successfully used with Unity `5.2.2f1` and `Swift 2.1` under `Xcode 7.1`.
+successfully used with Unity `5.2.2f1` and `Swift 2.1` under `Xcode 7.1` & `Swift 3.0` under `Xcode 8.0`.
 
 This works with storyboards.
 
@@ -230,8 +230,9 @@ import UIKit
 // overriding @UIApplicationMain
 // http://stackoverflow.com/a/24021180/1060314
 
-custom_unity_init(Process.argc, Process.unsafeArgv)
-UIApplicationMain(Process.argc, Process.unsafeArgv, NSStringFromClass(UIApplication), NSStringFromClass(AppDelegate))
+custom_unity_init(CommandLine.argc, CommandLine.unsafeArgv)
+let newUnsafeArgv = UnsafeMutableRawPointer( CommandLine.unsafeArgv ).bindMemory( to: UnsafeMutablePointer<Int8>.self, capacity: Int( CommandLine.argc ) )
+UIApplicationMain( CommandLine.argc, newUnsafeArgv , NSStringFromClass( UIApplication.self ), NSStringFromClass( AppDelegate.self ) )
 ```
 
 Assuming your bridging header is properly registered, xcode will NOT be


### PR DESCRIPTION
This PR fixes problems with the new Swift version 3.0, as mentioned in #18 

The reason for:

`let newUnsafeArgv = UnsafeMutableRawPointer( CommandLine.unsafeArgv ).bindMemory( to: UnsafeMutablePointer<Int8>.self, capacity: Int( CommandLine.argc ) )` 

is because the `CommandLine.unsafeArgv` signature no longer is a straight match to the signature of `UIApplicationMain()` as outlined here: https://forums.developer.apple.com/thread/46405
